### PR TITLE
Moves the Dracula theme into Textmate's dark theme category

### DIFF
--- a/Dracula.tmTheme
+++ b/Dracula.tmTheme
@@ -528,7 +528,7 @@
 	<key>colorSpaceName</key>
 	<string>sRGB</string>
 	<key>semanticClass</key>
-	<string>theme.dracula</string>
+	<string>theme.dark.dracula</string>
 	<key>author</key>
 	<string>Zeno Rocha</string>
 </dict>


### PR DESCRIPTION
This fix moves the theme into Textmate's 'Dark' theme category.